### PR TITLE
Fix requirement of elderly person

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -16,7 +16,7 @@ As we have noticed lately, there are some basic questions almost everyone we mee
 <b>A: </b>No! the only reason for the membership is, we also need to pay rent, we give out keys and have other perks for guys ( and girls ) who are registered as member. We will ask you not to change your subscription every month because there is some administration involved for us, and like you, we also like to hack stuff most of the time.
 
 <b>Q: </b><i>I am under 18, can i still become a member ?</i><br />
-<b>A: </b>Yes, you can become a member. The only reason the "Are you over 18" question is on our form is simply because of responsibility. At Pixelbar we have big machinery and other tools like soldering irons available. If you are under 18, there will always have to be an elderly person around for you to operate the big machines. We will happily invite you over and talk about the responsibilities which work both ways.
+<b>A: </b>Yes, you can become a member. The only reason the "Are you over 18" question is on our form is simply because of responsibility. At Pixelbar we have big machinery and other tools like soldering irons available. If you are under 18, there will always have to be an adult person around for you to operate the big machines. We will happily invite you over and talk about the responsibilities which work both ways.
 
 <b>Q: </b><i>Do i need to have minimal skills for joining Pixelbar?</i><br />
 <b>A: </b>No. Pixelbar is just a please where we learn things by doing it. Even if you never touched an Arduino, Written a "Hello World" program or soldered some electronic parts together you are very welcome to learn to do so. People learn from doing stuff. We are happy to help you if you're stuck on something.


### PR DESCRIPTION
This PR changes the wording that says an `elderly` ("bejaard" / 70+) person must be present for an < 18 yo to operate machinery. I think an `adult` ("volwassene", 18+) will do.